### PR TITLE
feat(deps): bump cluster-template to v1.4.0

### DIFF
--- a/.holo/sources/cluster-template.toml
+++ b/.holo/sources/cluster-template.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/JarvusInnovations/cluster-template"
-ref = "refs/tags/v1.3.4"
+ref = "refs/tags/v1.4.0"


### PR DESCRIPTION
Picks up cert-manager 1.20.2 (was 1.13.3) from upstream, which adds Gateway API ListenerSet support for downstream consumers migrating off ingress-nginx.

Upstream: JarvusInnovations/cluster-template#55, #56