### PR TITLE
fix(deps): bump cluster-template to v1.4.1

### DIFF
--- a/.holo/sources/cluster-template.toml
+++ b/.holo/sources/cluster-template.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/JarvusInnovations/cluster-template"
-ref = "refs/tags/v1.4.0"
+ref = "refs/tags/v1.4.1"


### PR DESCRIPTION
Picks up cluster-template v1.4.1, which drops cert-manager's stale upstream `helm-values.yaml` mapping that was failing chart schema validation after the v1.20 bump.

Downstream consumers can now drop their workspace `cert-manager/helm-values.yaml` override after this lands.

Upstream: JarvusInnovations/cluster-template#57, #58