### PR TITLE
feat(deps): bump cluster-template to v1.5.0

### DIFF
--- a/.holo/sources/cluster-template.toml
+++ b/.holo/sources/cluster-template.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/JarvusInnovations/cluster-template"
-ref = "refs/tags/v1.4.1"
+ref = "refs/tags/v1.5.0"


### PR DESCRIPTION
Picks up Envoy Gateway + Gateway API v1.5.1 CRDs + cert-manager Gateway API integration (with ListenerSet feature gate) from upstream.

Foundation for downstream clusters to migrate off ingress-nginx onto Gateway API.

Upstream: JarvusInnovations/cluster-template#59, #60