### PR TITLE
fix(deps): bump cluster-template to v1.5.1

### DIFF
--- a/.holo/sources/cluster-template.toml
+++ b/.holo/sources/cluster-template.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/JarvusInnovations/cluster-template"
-ref = "refs/tags/v1.5.0"
+ref = "refs/tags/v1.5.1"


### PR DESCRIPTION
Picks up the cert-manager ListenerSets feature gate name fix.

Without it, cert-manager controller crash-loops on startup with `unrecognized feature gate: ListenerSet` (it's `ListenerSets` plural in cert-manager's code).

Upstream: JarvusInnovations/cluster-template#61, #62