### PR TITLE
chore(deps): bump cluster-template to v1.5.2

### DIFF
--- a/.holo/sources/cluster-template.toml
+++ b/.holo/sources/cluster-template.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/JarvusInnovations/cluster-template"
-ref = "refs/tags/v1.5.1"
+ref = "refs/tags/v1.5.2"


### PR DESCRIPTION
## Summary

Bumps `cluster-template` source pin to v1.5.2, which removes `hairpin-proxy` from the LKE blueprint (JarvusInnovations/cluster-template#63).

## Why

- **Linode LKE now supports LoadBalancer hairpin natively** — verified by reaching the cluster's own LB external IP from inside a pod
- **hairpin-proxy is actively harmful with Envoy Gateway** — it hardcodes ingress-nginx as the routing target, so in-cluster requests bypass the new Envoy data plane. Breaks cert-manager HTTP-01 self-check among other things.

## Downstream impact

Downstream LKE clusters will see the following drop out of their projected manifests:

- `hairpin-proxy` Namespace
- `hairpin-proxy-controller` Deployment + RBAC
- `hairpin-proxy-haproxy` Deployment + Service
- `coredns-custom` ConfigMap rewrites

Operators of running clusters should clear the dynamically-added rewrites in `coredns-custom` after upgrading (one `kubectl patch` to set `hairpin-proxy.include` to empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)